### PR TITLE
feat: add browser-based one-click login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_PASSWORD=YOUR_MYSQL_PASSWORD
 DB_NAME=lark_messages
 
 # Lark API configuration
+# Cookie can be obtained automatically with: python main.py --login
+# Or set manually:
 LARK_COOKIE="YOUR LARK Cookie"
 
 # Function trigger flag

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,10 +1,12 @@
 from http.cookies import SimpleCookie
+from loguru import logger
 
 from app.config.settings import settings
 
+
 class LarkAuth:
     """Authentication for Lark API"""
-    
+
     def __init__(self, cookie_str=None):
         """Initialize LarkAuth with optional cookie string"""
         self.cookie = {}
@@ -12,7 +14,14 @@ class LarkAuth:
             self.prepare_auth(cookie_str)
         elif settings.LARK_COOKIE:
             self.prepare_auth(settings.LARK_COOKIE)
-    
+        else:
+            # Try to load from saved cookie file
+            from app.api.browser_login import load_cookie_from_file
+            saved_cookie = load_cookie_from_file()
+            if saved_cookie:
+                logger.info("Loaded cookie from saved file")
+                self.prepare_auth(saved_cookie)
+
     def prepare_auth(self, cookie_str):
         """Process cookie string to dict format"""
         cookie = SimpleCookie()
@@ -20,6 +29,11 @@ class LarkAuth:
         self.cookie = {k: v.value for k, v in cookie.items()}
         return self.cookie
 
+    def is_authenticated(self):
+        """Check if we have valid authentication cookies"""
+        return bool(self.cookie)
+
+
 def get_auth():
     """Get LarkAuth instance with cookie from config"""
-    return LarkAuth() 
+    return LarkAuth()

--- a/app/api/browser_login.py
+++ b/app/api/browser_login.py
@@ -1,0 +1,125 @@
+"""
+Browser-based login for Feishu/Lark.
+Opens a browser window for the user to login and captures the session cookie.
+"""
+import os
+import json
+import asyncio
+from loguru import logger
+
+# Cookie storage path
+COOKIE_FILE = os.path.expanduser("~/.lark/msg/cookie.json")
+LOGIN_URL = "https://www.feishu.cn/messenger/"
+# Required cookie that indicates successful login
+AUTH_COOKIE_NAME = "session"
+
+
+def ensure_cookie_dir():
+    """Ensure the cookie storage directory exists"""
+    os.makedirs(os.path.dirname(COOKIE_FILE), exist_ok=True)
+
+
+def save_cookie_to_file(cookie_str: str):
+    """Save cookie string to local file"""
+    ensure_cookie_dir()
+    with open(COOKIE_FILE, 'w') as f:
+        json.dump({"cookie": cookie_str}, f)
+    logger.info(f"Cookie saved to {COOKIE_FILE}")
+
+
+def load_cookie_from_file() -> str:
+    """Load cookie string from local file"""
+    if not os.path.exists(COOKIE_FILE):
+        return ""
+    try:
+        with open(COOKIE_FILE, 'r') as f:
+            data = json.load(f)
+            return data.get("cookie", "")
+    except Exception as e:
+        logger.warning(f"Failed to load cookie from file: {e}")
+        return ""
+
+
+def clear_saved_cookie():
+    """Remove saved cookie file"""
+    if os.path.exists(COOKIE_FILE):
+        os.remove(COOKIE_FILE)
+        logger.info("Saved cookie cleared")
+
+
+async def browser_login(timeout: int = 180) -> str:
+    """
+    Open a browser for Feishu login and capture cookies.
+
+    Args:
+        timeout: Maximum wait time in seconds (default: 3 minutes)
+
+    Returns:
+        Cookie string for API authentication
+
+    Raises:
+        TimeoutError: If login is not completed within timeout
+        ImportError: If playwright is not installed
+    """
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError:
+        raise ImportError(
+            "playwright is required for browser login. "
+            "Install with: pip install playwright && playwright install chromium"
+        )
+
+    logger.info("Starting browser login...")
+    logger.info(f"Opening {LOGIN_URL}")
+    logger.info(f"Please login within {timeout} seconds...")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        context = await browser.new_context()
+        page = await context.new_page()
+
+        await page.goto(LOGIN_URL)
+
+        # Poll for login completion by checking cookies
+        import time
+        start_time = time.time()
+        cookie_str = ""
+
+        while time.time() - start_time < timeout:
+            cookies = await context.cookies()
+
+            # Check for session cookie that indicates successful login
+            has_session = any(
+                c['name'] in ('session', 'session_list', 'passport_web_did')
+                for c in cookies
+            )
+
+            # Also check if we've navigated to messenger (login complete)
+            current_url = page.url
+            if has_session and ('messenger' in current_url or 'suite' in current_url):
+                # Build cookie string
+                cookie_str = "; ".join(f"{c['name']}={c['value']}" for c in cookies)
+                logger.info("Login successful! Cookie captured.")
+                break
+
+            await asyncio.sleep(1)
+
+        await browser.close()
+
+    if not cookie_str:
+        raise TimeoutError(f"Login not completed within {timeout} seconds")
+
+    # Save cookie to file
+    save_cookie_to_file(cookie_str)
+
+    return cookie_str
+
+
+def login_interactive(timeout: int = 180) -> str:
+    """
+    Synchronous wrapper for browser login.
+
+    Returns:
+        Cookie string for API authentication
+    """
+    return asyncio.run(browser_login(timeout))

--- a/main.py
+++ b/main.py
@@ -2,19 +2,53 @@
 Lark Message Recorder - Main Entry Point
 Records all received Lark messages to a MySQL database.
 """
+import argparse
 import multiprocessing
 import sys
 import asyncio
 from loguru import logger
+
 
 def start_mcp_server():
     """Start the MCP server in a separate process"""
     logger.info("Starting MCP server...")
     from app.core.mcp_server import mcp
     mcp.run(transport="stdio")
-    
+
+
+async def do_login(timeout=180):
+    """Perform browser-based login"""
+    from app.api.browser_login import browser_login
+    try:
+        cookie = await browser_login(timeout)
+        logger.info("Login successful! You can now run the agent.")
+        return cookie
+    except ImportError as e:
+        logger.error(str(e))
+        sys.exit(1)
+    except TimeoutError as e:
+        logger.error(str(e))
+        sys.exit(1)
+
+
 async def main():
     """Main function to run the Lark message recorder"""
+    parser = argparse.ArgumentParser(description="LarkAgentX - Feishu/Lark AI Agent")
+    parser.add_argument("--login", action="store_true", help="Login via browser and save cookie")
+    parser.add_argument("--logout", action="store_true", help="Clear saved cookie")
+    parser.add_argument("--login-timeout", type=int, default=180, help="Browser login timeout in seconds")
+    args = parser.parse_args()
+
+    if args.logout:
+        from app.api.browser_login import clear_saved_cookie
+        clear_saved_cookie()
+        logger.info("Logged out successfully")
+        return
+
+    if args.login:
+        await do_login(args.login_timeout)
+        return
+
     from app.db.session import init_db
     from app.api.auth import get_auth
     from app.api.lark_client import LarkClient
@@ -30,15 +64,19 @@ async def main():
     except Exception as e:
         logger.error(f"数据库初始化失败: {str(e)}")
         sys.exit(1)
-    
+
     logger.info("初始化认证...")
     try:
         auth = get_auth()
+        if not auth.is_authenticated():
+            logger.warning("未找到认证信息，请先运行: python main.py --login")
+            logger.info("或设置环境变量 LARK_COOKIE")
+            sys.exit(1)
         logger.info("认证初始化成功.")
     except Exception as e:
         logger.error(f"认证初始化失败: {str(e)}")
         sys.exit(1)
-    
+
     logger.info("创建 Lark 客户端...")
     try:
         lark_client = LarkClient(auth)
@@ -46,10 +84,10 @@ async def main():
     except Exception as e:
         logger.error(f"Lark 客户端创建失败: {str(e)}")
         sys.exit(1)
-    
+
     logger.info("创建消息服务...")
     message_service = MessageService(lark_client)
-    
+
     try:
         logger.info("连接到 Lark WebSocket...")
         logger.info("开始接收消息...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ websockets==15.0.1
 fastmcp==2.1.2
 Brotli==1.1.0
 cryptography==44.0.2
+# Browser login (optional): pip install playwright && playwright install chromium
+playwright>=1.40.0


### PR DESCRIPTION
## Summary

Add automatic cookie capture via browser login, eliminating the need to manually extract and set `LARK_COOKIE` environment variable.

### Features

- **Browser login** — Opens Feishu login page in Chromium, captures session cookies after login
- **Cookie persistence** — Saved to `~/.lark/msg/cookie.json` for reuse across sessions
- **Auto-load** — Auth layer automatically loads saved cookie when `LARK_COOKIE` env var is not set
- **CLI integration** — `--login` / `--logout` / `--login-timeout` arguments

### Usage

```bash
# First time: login via browser
python main.py --login

# Run the agent (cookie auto-loaded)
python main.py

# Clear saved cookie
python main.py --logout
```

### Changes

- `app/api/browser_login.py` (new) — Playwright-based login with cookie capture and persistence
- `app/api/auth.py` — Add `is_authenticated()` check, auto-load saved cookie as fallback
- `main.py` — Add argparse with `--login`/`--logout`/`--login-timeout` flags
- `requirements.txt` — Add `playwright>=1.40.0` (optional dependency)
- `.env.example` — Add comment about `--login` option

## Test plan

- [ ] `python main.py --login` opens browser and captures cookie after login
- [ ] Cookie is saved to `~/.lark/msg/cookie.json`
- [ ] `python main.py` loads saved cookie automatically
- [ ] `python main.py --logout` clears saved cookie
- [ ] Running without cookie shows helpful error message
- [ ] Still works with `LARK_COOKIE` env var (takes priority over saved file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)